### PR TITLE
ADD: Reading multiple videos from folder if exists

### DIFF
--- a/DanceStages/(REPLICANT) DARK BLUE/LoaderA.lua
+++ b/DanceStages/(REPLICANT) DARK BLUE/LoaderA.lua
@@ -3,6 +3,8 @@ local movieRate = string.find(_VERSION, 5.3) and 1 or (1/21)
 local list = {}
 local callvideo = {}
 local Loop = 0
+local videosplace = "/DanceStages/StageMovies/"
+
 
 ------- FUNCTIONS  -------
 
@@ -15,33 +17,57 @@ local function GetSong()
 end
 
 local function setVariables()
-	Loop = 0
-	
-	if HasVideo() then
-		VideoFileType = {"mp4","avi","mov","m2ts","m2v","wmv","mpg","mpeg"}
-		for i=1,#VideoFileType do
-			if FILEMAN:DoesFileExist(GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]) then
-				VideoTexture = GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]
-				Loop=0
-				break
-			end
-		end
-	else
-		list = FILEMAN:GetDirListing("/DanceStages/StageMovies/")
-		if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
-			for i = 1, 7 do
-				table.insert(callvideo,i,list[math.random(#list)])
-			end
-			VideoTexture = "Black.png"
-		else
-			if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
-				VideoTexture = GetSong():GetJacketPath()
-			else
-				VideoTexture = "Black.png"
-			end
-		end
-		Loop=1
-	end
+    Loop = 0
+    callvideo = {}
+
+    if HasVideo() then
+        local VideoFileType = {"mp4", "avi", "mov", "m2ts", "m2v", "wmv", "mpg", "mpeg"}
+        local songPath = GetSong():GetSongDir()
+        local files = FILEMAN:GetDirListing(songPath, false, false)
+        local videoList = {}
+
+        -- Buscar todos los videos en la carpeta de la canción
+        for _, file in ipairs(files) do
+            for _, ext in ipairs(VideoFileType) do
+                if file:match("%." .. ext .. "$") then
+                    table.insert(videoList,file)
+                end
+            end
+        end
+        if #videoList > 1 then
+            for i = #videoList, 2, -1 do
+                local j = math.random(i)
+                videoList[i], videoList[j] = videoList[j], videoList[i] -- Random swap
+            end
+
+            for i = 1, math.min(#videoList, 12) do
+                table.insert(callvideo, videoList[i])
+            end
+
+			videosplace = songPath
+            VideoTexture = "Black.png" -- Placeholder
+            Loop = 1
+        else
+            VideoTexture = videoList[1]
+            Loop = 0
+        end
+
+    else
+        list = FILEMAN:GetDirListing(videosplace)
+        if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
+            for i = 1, 7 do
+                table.insert(callvideo, list[math.random(#list)])
+            end
+            VideoTexture = "Black.png"
+        else
+            if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
+                VideoTexture = GetSong():GetJacketPath()
+            else
+                VideoTexture = "Black.png"
+            end
+        end
+        Loop = 1
+    end
 end
 
 local function SongMeasureSec()
@@ -139,25 +165,25 @@ local function MovieBackground(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
 			end,
 		},
 	}
@@ -195,25 +221,25 @@ function Display(X, Y, Z, rX, rY, rZ)
 			end
 		end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		}
 	}
@@ -261,25 +287,25 @@ function Circle(Z,Y,Zo,DA)
 				end
 			end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		};
 }

--- a/DanceStages/(REPLICANT) DARK PURPLE/LoaderA.lua
+++ b/DanceStages/(REPLICANT) DARK PURPLE/LoaderA.lua
@@ -3,6 +3,7 @@ local movieRate = string.find(_VERSION, 5.3) and 1 or (1/21)
 local list = {}
 local callvideo = {}
 local Loop = 0
+local videosplace = "/DanceStages/StageMovies/"
 
 ------- FUNCTIONS  -------
 
@@ -15,33 +16,57 @@ local function GetSong()
 end
 
 local function setVariables()
-	Loop = 0
-	
-	if HasVideo() then
-		VideoFileType = {"mp4","avi","mov","m2ts","m2v","wmv","mpg","mpeg"}
-		for i=1,#VideoFileType do
-			if FILEMAN:DoesFileExist(GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]) then
-				VideoTexture = GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]
-				Loop=0
-				break
-			end
-		end
-	else
-		list = FILEMAN:GetDirListing("/DanceStages/StageMovies/")
-		if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
-			for i = 1, 7 do
-				table.insert(callvideo,i,list[math.random(#list)])
-			end
-			VideoTexture = "Black.png"
-		else
-			if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
-				VideoTexture = GetSong():GetJacketPath()
-			else
-				VideoTexture = "Black.png"
-			end
-		end
-		Loop=1
-	end
+    Loop = 0
+    callvideo = {}
+
+    if HasVideo() then
+        local VideoFileType = {"mp4", "avi", "mov", "m2ts", "m2v", "wmv", "mpg", "mpeg"}
+        local songPath = GetSong():GetSongDir()
+        local files = FILEMAN:GetDirListing(songPath, false, false)
+        local videoList = {}
+
+        -- Buscar todos los videos en la carpeta de la canción
+        for _, file in ipairs(files) do
+            for _, ext in ipairs(VideoFileType) do
+                if file:match("%." .. ext .. "$") then
+                    table.insert(videoList,file)
+                end
+            end
+        end
+        if #videoList > 1 then
+            for i = #videoList, 2, -1 do
+                local j = math.random(i)
+                videoList[i], videoList[j] = videoList[j], videoList[i] -- Random swap
+            end
+
+            for i = 1, math.min(#videoList, 12) do
+                table.insert(callvideo, videoList[i])
+            end
+
+			videosplace = songPath
+            VideoTexture = "Black.png" -- Placeholder
+            Loop = 1
+        else
+            VideoTexture = videoList[1]
+            Loop = 0
+        end
+
+    else
+        list = FILEMAN:GetDirListing(videosplace)
+        if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
+            for i = 1, 7 do
+                table.insert(callvideo, list[math.random(#list)])
+            end
+            VideoTexture = "Black.png"
+        else
+            if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
+                VideoTexture = GetSong():GetJacketPath()
+            else
+                VideoTexture = "Black.png"
+            end
+        end
+        Loop = 1
+    end
 end
 
 local function SongMeasureSec()
@@ -139,25 +164,25 @@ local function MovieBackground(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
 			end,
 		},
 	}
@@ -195,25 +220,25 @@ function Display(X, Y, Z, rX, rY, rZ)
 			end
 		end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		}
 	}
@@ -261,25 +286,25 @@ function Circle(Z,Y,Zo,DA)
 				end
 			end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		};
 }

--- a/DanceStages/(REPLICANT) LIGHT BLUE/LoaderA.lua
+++ b/DanceStages/(REPLICANT) LIGHT BLUE/LoaderA.lua
@@ -3,6 +3,7 @@ local movieRate = string.find(_VERSION, 5.3) and 1 or (1/21)
 local list = {}
 local callvideo = {}
 local Loop = 0
+local videosplace = "/DanceStages/StageMovies/"
 
 ------- FUNCTIONS  -------
 
@@ -15,33 +16,57 @@ local function GetSong()
 end
 
 local function setVariables()
-	Loop = 0
-	
-	if HasVideo() then
-		VideoFileType = {"mp4","avi","mov","m2ts","m2v","wmv","mpg","mpeg"}
-		for i=1,#VideoFileType do
-			if FILEMAN:DoesFileExist(GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]) then
-				VideoTexture = GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]
-				Loop=0
-				break
-			end
-		end
-	else
-		list = FILEMAN:GetDirListing("/DanceStages/StageMovies/")
-		if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
-			for i = 1, 7 do
-				table.insert(callvideo,i,list[math.random(#list)])
-			end
-			VideoTexture = "Black.png"
-		else
-			if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
-				VideoTexture = GetSong():GetJacketPath()
-			else
-				VideoTexture = "Black.png"
-			end
-		end
-		Loop=1
-	end
+    Loop = 0
+    callvideo = {}
+
+    if HasVideo() then
+        local VideoFileType = {"mp4", "avi", "mov", "m2ts", "m2v", "wmv", "mpg", "mpeg"}
+        local songPath = GetSong():GetSongDir()
+        local files = FILEMAN:GetDirListing(songPath, false, false)
+        local videoList = {}
+
+        -- Buscar todos los videos en la carpeta de la canción
+        for _, file in ipairs(files) do
+            for _, ext in ipairs(VideoFileType) do
+                if file:match("%." .. ext .. "$") then
+                    table.insert(videoList,file)
+                end
+            end
+        end
+        if #videoList > 1 then
+            for i = #videoList, 2, -1 do
+                local j = math.random(i)
+                videoList[i], videoList[j] = videoList[j], videoList[i] -- Random swap
+            end
+
+            for i = 1, math.min(#videoList, 12) do
+                table.insert(callvideo, videoList[i])
+            end
+
+			videosplace = songPath
+            VideoTexture = "Black.png" -- Placeholder
+            Loop = 1
+        else
+            VideoTexture = videoList[1]
+            Loop = 0
+        end
+
+    else
+        list = FILEMAN:GetDirListing(videosplace)
+        if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
+            for i = 1, 7 do
+                table.insert(callvideo, list[math.random(#list)])
+            end
+            VideoTexture = "Black.png"
+        else
+            if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
+                VideoTexture = GetSong():GetJacketPath()
+            else
+                VideoTexture = "Black.png"
+            end
+        end
+        Loop = 1
+    end
 end
 
 local function SongMeasureSec()
@@ -139,25 +164,25 @@ local function MovieBackground(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
 			end,
 		},
 	}
@@ -195,25 +220,25 @@ function Display(X, Y, Z, rX, rY, rZ)
 			end
 		end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		}
 	}
@@ -261,25 +286,25 @@ function Circle(Z,Y,Zo,DA)
 				end
 			end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		};
 }

--- a/DanceStages/(REPLICANT) LIGHT GRAY/LoaderA.lua
+++ b/DanceStages/(REPLICANT) LIGHT GRAY/LoaderA.lua
@@ -3,6 +3,7 @@ local movieRate = string.find(_VERSION, 5.3) and 1 or (1/21)
 local list = {}
 local callvideo = {}
 local Loop = 0
+local videosplace = "/DanceStages/StageMovies/"
 
 ------- FUNCTIONS  -------
 
@@ -15,33 +16,57 @@ local function GetSong()
 end
 
 local function setVariables()
-	Loop = 0
-	
-	if HasVideo() then
-		VideoFileType = {"mp4","avi","mov","m2ts","m2v","wmv","mpg","mpeg"}
-		for i=1,#VideoFileType do
-			if FILEMAN:DoesFileExist(GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]) then
-				VideoTexture = GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]
-				Loop=0
-				break
-			end
-		end
-	else
-		list = FILEMAN:GetDirListing("/DanceStages/StageMovies/")
-		if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
-			for i = 1, 7 do
-				table.insert(callvideo,i,list[math.random(#list)])
-			end
-			VideoTexture = "Black.png"
-		else
-			if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
-				VideoTexture = GetSong():GetJacketPath()
-			else
-				VideoTexture = "Black.png"
-			end
-		end
-		Loop=1
-	end
+    Loop = 0
+    callvideo = {}
+
+    if HasVideo() then
+        local VideoFileType = {"mp4", "avi", "mov", "m2ts", "m2v", "wmv", "mpg", "mpeg"}
+        local songPath = GetSong():GetSongDir()
+        local files = FILEMAN:GetDirListing(songPath, false, false)
+        local videoList = {}
+
+        -- Buscar todos los videos en la carpeta de la canción
+        for _, file in ipairs(files) do
+            for _, ext in ipairs(VideoFileType) do
+                if file:match("%." .. ext .. "$") then
+                    table.insert(videoList,file)
+                end
+            end
+        end
+        if #videoList > 1 then
+            for i = #videoList, 2, -1 do
+                local j = math.random(i)
+                videoList[i], videoList[j] = videoList[j], videoList[i] -- Random swap
+            end
+
+            for i = 1, math.min(#videoList, 12) do
+                table.insert(callvideo, videoList[i])
+            end
+
+			videosplace = songPath
+            VideoTexture = "Black.png" -- Placeholder
+            Loop = 1
+        else
+            VideoTexture = videoList[1]
+            Loop = 0
+        end
+
+    else
+        list = FILEMAN:GetDirListing(videosplace)
+        if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
+            for i = 1, 7 do
+                table.insert(callvideo, list[math.random(#list)])
+            end
+            VideoTexture = "Black.png"
+        else
+            if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
+                VideoTexture = GetSong():GetJacketPath()
+            else
+                VideoTexture = "Black.png"
+            end
+        end
+        Loop = 1
+    end
 end
 
 local function SongMeasureSec()
@@ -139,25 +164,25 @@ local function MovieBackground(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
 			end,
 		},
 	}
@@ -195,25 +220,25 @@ function Display(X, Y, Z, rX, rY, rZ)
 			end
 		end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		}
 	}
@@ -261,25 +286,25 @@ function Circle(Z,Y,Zo,DA)
 				end
 			end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		};
 }

--- a/DanceStages/(REPLICANT) LIGHT PURPLE/LoaderA.lua
+++ b/DanceStages/(REPLICANT) LIGHT PURPLE/LoaderA.lua
@@ -3,6 +3,7 @@ local movieRate = string.find(_VERSION, 5.3) and 1 or (1/21)
 local list = {}
 local callvideo = {}
 local Loop = 0
+local videosplace = "/DanceStages/StageMovies/"
 
 ------- FUNCTIONS  -------
 
@@ -15,33 +16,57 @@ local function GetSong()
 end
 
 local function setVariables()
-	Loop = 0
-	
-	if HasVideo() then
-		VideoFileType = {"mp4","avi","mov","m2ts","m2v","wmv","mpg","mpeg"}
-		for i=1,#VideoFileType do
-			if FILEMAN:DoesFileExist(GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]) then
-				VideoTexture = GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]
-				Loop=0
-				break
-			end
-		end
-	else
-		list = FILEMAN:GetDirListing("/DanceStages/StageMovies/")
-		if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
-			for i = 1, 7 do
-				table.insert(callvideo,i,list[math.random(#list)])
-			end
-			VideoTexture = "Black.png"
-		else
-			if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
-				VideoTexture = GetSong():GetJacketPath()
-			else
-				VideoTexture = "Black.png"
-			end
-		end
-		Loop=1
-	end
+    Loop = 0
+    callvideo = {}
+
+    if HasVideo() then
+        local VideoFileType = {"mp4", "avi", "mov", "m2ts", "m2v", "wmv", "mpg", "mpeg"}
+        local songPath = GetSong():GetSongDir()
+        local files = FILEMAN:GetDirListing(songPath, false, false)
+        local videoList = {}
+
+        -- Buscar todos los videos en la carpeta de la canción
+        for _, file in ipairs(files) do
+            for _, ext in ipairs(VideoFileType) do
+                if file:match("%." .. ext .. "$") then
+                    table.insert(videoList,file)
+                end
+            end
+        end
+        if #videoList > 1 then
+            for i = #videoList, 2, -1 do
+                local j = math.random(i)
+                videoList[i], videoList[j] = videoList[j], videoList[i] -- Random swap
+            end
+
+            for i = 1, math.min(#videoList, 12) do
+                table.insert(callvideo, videoList[i])
+            end
+
+			videosplace = songPath
+            VideoTexture = "Black.png" -- Placeholder
+            Loop = 1
+        else
+            VideoTexture = videoList[1]
+            Loop = 0
+        end
+
+    else
+        list = FILEMAN:GetDirListing(videosplace)
+        if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
+            for i = 1, 7 do
+                table.insert(callvideo, list[math.random(#list)])
+            end
+            VideoTexture = "Black.png"
+        else
+            if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
+                VideoTexture = GetSong():GetJacketPath()
+            else
+                VideoTexture = "Black.png"
+            end
+        end
+        Loop = 1
+    end
 end
 
 local function SongMeasureSec()
@@ -139,25 +164,25 @@ local function MovieBackground(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
 			end,
 		},
 	}
@@ -195,25 +220,25 @@ function Display(X, Y, Z, rX, rY, rZ)
 			end
 		end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		}
 	}
@@ -261,25 +286,25 @@ function Circle(Z,Y,Zo,DA)
 				end
 			end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		};
 }

--- a/DanceStages/(REPLICANT) RED/LoaderA.lua
+++ b/DanceStages/(REPLICANT) RED/LoaderA.lua
@@ -3,6 +3,7 @@ local movieRate = string.find(_VERSION, 5.3) and 1 or (1/21)
 local list = {}
 local callvideo = {}
 local Loop = 0
+local videosplace = "/DanceStages/StageMovies/"
 
 ------- FUNCTIONS  -------
 
@@ -15,33 +16,57 @@ local function GetSong()
 end
 
 local function setVariables()
-	Loop = 0
-	
-	if HasVideo() then
-		VideoFileType = {"mp4","avi","mov","m2ts","m2v","wmv","mpg","mpeg"}
-		for i=1,#VideoFileType do
-			if FILEMAN:DoesFileExist(GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]) then
-				VideoTexture = GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]
-				Loop=0
-				break
-			end
-		end
-	else
-		list = FILEMAN:GetDirListing("/DanceStages/StageMovies/")
-		if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
-			for i = 1, 7 do
-				table.insert(callvideo,i,list[math.random(#list)])
-			end
-			VideoTexture = "Black.png"
-		else
-			if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
-				VideoTexture = GetSong():GetJacketPath()
-			else
-				VideoTexture = "Black.png"
-			end
-		end
-		Loop=1
-	end
+    Loop = 0
+    callvideo = {}
+
+    if HasVideo() then
+        local VideoFileType = {"mp4", "avi", "mov", "m2ts", "m2v", "wmv", "mpg", "mpeg"}
+        local songPath = GetSong():GetSongDir()
+        local files = FILEMAN:GetDirListing(songPath, false, false)
+        local videoList = {}
+
+        -- Buscar todos los videos en la carpeta de la canción
+        for _, file in ipairs(files) do
+            for _, ext in ipairs(VideoFileType) do
+                if file:match("%." .. ext .. "$") then
+                    table.insert(videoList,file)
+                end
+            end
+        end
+        if #videoList > 1 then
+            for i = #videoList, 2, -1 do
+                local j = math.random(i)
+                videoList[i], videoList[j] = videoList[j], videoList[i] -- Random swap
+            end
+
+            for i = 1, math.min(#videoList, 12) do
+                table.insert(callvideo, videoList[i])
+            end
+
+			videosplace = songPath
+            VideoTexture = "Black.png" -- Placeholder
+            Loop = 1
+        else
+            VideoTexture = videoList[1]
+            Loop = 0
+        end
+
+    else
+        list = FILEMAN:GetDirListing(videosplace)
+        if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
+            for i = 1, 7 do
+                table.insert(callvideo, list[math.random(#list)])
+            end
+            VideoTexture = "Black.png"
+        else
+            if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
+                VideoTexture = GetSong():GetJacketPath()
+            else
+                VideoTexture = "Black.png"
+            end
+        end
+        Loop = 1
+    end
 end
 
 local function SongMeasureSec()
@@ -139,25 +164,25 @@ local function MovieBackground(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
 			end,
 		},
 	}
@@ -195,25 +220,25 @@ function Display(X, Y, Z, rX, rY, rZ)
 			end
 		end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(28,20):rate(movieRate)
 			end;
 		}
 	}
@@ -261,25 +286,25 @@ function Circle(Z,Y,Zo,DA)
 				end
 			end,
 		FirstCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[1]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SecondCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[2]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		ThirdCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[3]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FourthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[4]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		FivethCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[5]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SixthCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[6]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		SeventhCommand=function(self)
-			self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
+			self:Load(videosplace..callvideo[7]):scaletoclipped(150,90):rate(movieRate)
 			end;
 		};
 }

--- a/DanceStages/(X2) MOVIE BLACK/LoaderA.lua
+++ b/DanceStages/(X2) MOVIE BLACK/LoaderA.lua
@@ -3,6 +3,7 @@ local movieRate = string.find(_VERSION, 5.3) and 1 or (1/18)
 local list = {}
 local callvideo = {}
 local Loop = 0
+local videosplace = "/DanceStages/StageMovies/"
 
 ------- FUNCTIONS  -------
 
@@ -15,33 +16,57 @@ local function GetSong()
 end
 
 local function setVariables()
-	Loop = 0
-	
-	if HasVideo() then
-		VideoFileType = {"mp4","avi","mov","m2ts","m2v","wmv","mpg","mpeg"}
-		for i=1,#VideoFileType do
-			if FILEMAN:DoesFileExist(GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]) then
-				VideoTexture = GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]
-				Loop=0
-				break
-			end
-		end
-	else
-		list = FILEMAN:GetDirListing("/DanceStages/StageMovies/")
-		if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
-			for i = 1, 7 do
-				table.insert(callvideo,i,list[math.random(#list)])
-			end
-			VideoTexture = "Black.png"
-		else
-			if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
-				VideoTexture = GetSong():GetJacketPath()
-			else
-				VideoTexture = "Black.png"
-			end
-		end
-		Loop=1
-	end
+    Loop = 0
+    callvideo = {}
+
+    if HasVideo() then
+        local VideoFileType = {"mp4", "avi", "mov", "m2ts", "m2v", "wmv", "mpg", "mpeg"}
+        local songPath = GetSong():GetSongDir()
+        local files = FILEMAN:GetDirListing(songPath, false, false)
+        local videoList = {}
+
+        -- Buscar todos los videos en la carpeta de la canción
+        for _, file in ipairs(files) do
+            for _, ext in ipairs(VideoFileType) do
+                if file:match("%." .. ext .. "$") then
+                    table.insert(videoList,file)
+                end
+            end
+        end
+        if #videoList > 1 then
+            for i = #videoList, 2, -1 do
+                local j = math.random(i)
+                videoList[i], videoList[j] = videoList[j], videoList[i] -- Random swap
+            end
+
+            for i = 1, math.min(#videoList, 12) do
+                table.insert(callvideo, videoList[i])
+            end
+
+			videosplace = songPath
+            VideoTexture = "Black.png" -- Placeholder
+            Loop = 1
+        else
+            VideoTexture = videoList[1]
+            Loop = 0
+        end
+
+    else
+        list = FILEMAN:GetDirListing(videosplace)
+        if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
+            for i = 1, 7 do
+                table.insert(callvideo, list[math.random(#list)])
+            end
+            VideoTexture = "Black.png"
+        else
+            if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
+                VideoTexture = GetSong():GetJacketPath()
+            else
+                VideoTexture = "Black.png"
+            end
+        end
+        Loop = 1
+    end
 end
 
 local function SongMeasureSec()
@@ -119,25 +144,25 @@ local function MovieBackground(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
 			end,
 		},
 	}
@@ -188,25 +213,25 @@ local function MovieMonitor(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 		},
 	}

--- a/DanceStages/(X2) MOVIE WHITE/LoaderA.lua
+++ b/DanceStages/(X2) MOVIE WHITE/LoaderA.lua
@@ -3,6 +3,7 @@ local movieRate = string.find(_VERSION, 5.3) and 1 or (1/18)
 local list = {}
 local callvideo = {}
 local Loop = 0
+local videosplace = "/DanceStages/StageMovies/"
 
 ------- FUNCTIONS  -------
 
@@ -15,33 +16,57 @@ local function GetSong()
 end
 
 local function setVariables()
-	Loop = 0
-	
-	if HasVideo() then
-		VideoFileType = {"mp4","avi","mov","m2ts","m2v","wmv","mpg","mpeg"}
-		for i=1,#VideoFileType do
-			if FILEMAN:DoesFileExist(GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]) then
-				VideoTexture = GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]
-				Loop=0
-				break
-			end
-		end
-	else
-		list = FILEMAN:GetDirListing("/DanceStages/StageMovies/")
-		if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
-			for i = 1, 7 do
-				table.insert(callvideo,i,list[math.random(#list)])
-			end
-			VideoTexture = "Black.png"
-		else
-			if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
-				VideoTexture = GetSong():GetJacketPath()
-			else
-				VideoTexture = "Black.png"
-			end
-		end
-		Loop=1
-	end
+    Loop = 0
+    callvideo = {}
+
+    if HasVideo() then
+        local VideoFileType = {"mp4", "avi", "mov", "m2ts", "m2v", "wmv", "mpg", "mpeg"}
+        local songPath = GetSong():GetSongDir()
+        local files = FILEMAN:GetDirListing(songPath, false, false)
+        local videoList = {}
+
+        -- Buscar todos los videos en la carpeta de la canción
+        for _, file in ipairs(files) do
+            for _, ext in ipairs(VideoFileType) do
+                if file:match("%." .. ext .. "$") then
+                    table.insert(videoList,file)
+                end
+            end
+        end
+        if #videoList > 1 then
+            for i = #videoList, 2, -1 do
+                local j = math.random(i)
+                videoList[i], videoList[j] = videoList[j], videoList[i] -- Random swap
+            end
+
+            for i = 1, math.min(#videoList, 12) do
+                table.insert(callvideo, videoList[i])
+            end
+
+			videosplace = songPath
+            VideoTexture = "Black.png" -- Placeholder
+            Loop = 1
+        else
+            VideoTexture = videoList[1]
+            Loop = 0
+        end
+
+    else
+        list = FILEMAN:GetDirListing(videosplace)
+        if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
+            for i = 1, 7 do
+                table.insert(callvideo, list[math.random(#list)])
+            end
+            VideoTexture = "Black.png"
+        else
+            if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
+                VideoTexture = GetSong():GetJacketPath()
+            else
+                VideoTexture = "Black.png"
+            end
+        end
+        Loop = 1
+    end
 end
 
 local function SongMeasureSec()
@@ -119,25 +144,25 @@ local function MovieBackground(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(15,8):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(15,8):rate(movieRate)
 			end,
 		},
 	}
@@ -188,25 +213,25 @@ local function MovieMonitor(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(170,93.7):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(170,93.7):rate(movieRate)
 			end,
 		},
 	}

--- a/DanceStages/(X2) UMU MOVIE/LoaderA.lua
+++ b/DanceStages/(X2) UMU MOVIE/LoaderA.lua
@@ -3,6 +3,7 @@ local movieRate = string.find(_VERSION, 5.3) and 1 or (1/19)
 local list = {}
 local callvideo = {}
 local Loop = 0
+local videosplace = "/DanceStages/StageMovies/"
 
 ------- FUNCTIONS  -------
 
@@ -15,33 +16,57 @@ local function GetSong()
 end
 
 local function setVariables()
-	Loop = 0
-	
-	if HasVideo() then
-		VideoFileType = {"mp4","avi","mov","m2ts","m2v","wmv","mpg","mpeg"}
-		for i=1,#VideoFileType do
-			if FILEMAN:DoesFileExist(GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]) then
-				VideoTexture = GetSong():GetMusicPath():sub(1, -4)..VideoFileType[i]
-				Loop=0
-				break
-			end
-		end
-	else
-		list = FILEMAN:GetDirListing("/DanceStages/StageMovies/")
-		if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
-			for i = 1, 7 do
-				table.insert(callvideo,i,list[math.random(#list)])
-			end
-			VideoTexture = "Black.png"
-		else
-			if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
-				VideoTexture = GetSong():GetJacketPath()
-			else
-				VideoTexture = "Black.png"
-			end
-		end
-		Loop=1
-	end
+    Loop = 0
+    callvideo = {}
+
+    if HasVideo() then
+        local VideoFileType = {"mp4", "avi", "mov", "m2ts", "m2v", "wmv", "mpg", "mpeg"}
+        local songPath = GetSong():GetSongDir()
+        local files = FILEMAN:GetDirListing(songPath, false, false)
+        local videoList = {}
+
+        -- Buscar todos los videos en la carpeta de la canción
+        for _, file in ipairs(files) do
+            for _, ext in ipairs(VideoFileType) do
+                if file:match("%." .. ext .. "$") then
+                    table.insert(videoList,file)
+                end
+            end
+        end
+        if #videoList > 1 then
+            for i = #videoList, 2, -1 do
+                local j = math.random(i)
+                videoList[i], videoList[j] = videoList[j], videoList[i] -- Random swap
+            end
+
+            for i = 1, math.min(#videoList, 12) do
+                table.insert(callvideo, videoList[i])
+            end
+
+			videosplace = songPath
+            VideoTexture = "Black.png" -- Placeholder
+            Loop = 1
+        else
+            VideoTexture = videoList[1]
+            Loop = 0
+        end
+
+    else
+        list = FILEMAN:GetDirListing(videosplace)
+        if #list ~= 0 and GetUserPref("RMStage") == "Random Movies" then
+            for i = 1, 7 do
+                table.insert(callvideo, list[math.random(#list)])
+            end
+            VideoTexture = "Black.png"
+        else
+            if FILEMAN:DoesFileExist(GetSong():GetJacketPath()) then
+                VideoTexture = GetSong():GetJacketPath()
+            else
+                VideoTexture = "Black.png"
+            end
+        end
+        Loop = 1
+    end
 end
 
 local function SongMeasureSec()
@@ -120,25 +145,25 @@ function Monitor(X, Y, Z, rX, rY, rZ)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load("/DanceStages/StageMovies/"..callvideo[1]):scaletoclipped(40,30):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(40,30):rate(movieRate)
 				end;
 			SecondCommand=function(self)
-				self:Load("/DanceStages/StageMovies/"..callvideo[2]):scaletoclipped(40,30):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(40,30):rate(movieRate)
 				end;
 			ThirdCommand=function(self)
-				self:Load("/DanceStages/StageMovies/"..callvideo[3]):scaletoclipped(40,30):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(40,30):rate(movieRate)
 				end;
 			FourthCommand=function(self)
-				self:Load("/DanceStages/StageMovies/"..callvideo[4]):scaletoclipped(40,30):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(40,30):rate(movieRate)
 				end;
 			FivethCommand=function(self)
-				self:Load("/DanceStages/StageMovies/"..callvideo[5]):scaletoclipped(40,30):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(40,30):rate(movieRate)
 				end;
 			SixthCommand=function(self)
-				self:Load("/DanceStages/StageMovies/"..callvideo[6]):scaletoclipped(40,30):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(40,30):rate(movieRate)
 				end;
 			SeventhCommand=function(self)
-				self:Load("/DanceStages/StageMovies/"..callvideo[7]):scaletoclipped(40,30):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(40,30):rate(movieRate)
 				end;
 			};
 
@@ -182,25 +207,25 @@ function BigMonitor(x,z,rY,cL,cR)
 				end
 			end,
 			FirstCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[1]):scaletoclipped(6,4):rate(movieRate)
+				self:Load(videosplace..callvideo[1]):scaletoclipped(6,4):rate(movieRate)
 			end,
 			SecondCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[2]):scaletoclipped(6,4):rate(movieRate)
+				self:Load(videosplace..callvideo[2]):scaletoclipped(6,4):rate(movieRate)
 			end,
 			ThirdCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[3]):scaletoclipped(6,4):rate(movieRate)
+				self:Load(videosplace..callvideo[3]):scaletoclipped(6,4):rate(movieRate)
 			end,
 			FourthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[4]):scaletoclipped(6,4):rate(movieRate)
+				self:Load(videosplace..callvideo[4]):scaletoclipped(6,4):rate(movieRate)
 			end,
 			FivethCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[5]):scaletoclipped(6,4):rate(movieRate)
+				self:Load(videosplace..callvideo[5]):scaletoclipped(6,4):rate(movieRate)
 			end,
 			SixthCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[6]):scaletoclipped(6,4):rate(movieRate)
+				self:Load(videosplace..callvideo[6]):scaletoclipped(6,4):rate(movieRate)
 			end,
 			SeventhCommand=function(self)
-				self:Load('/DanceStages/StageMovies/'..callvideo[7]):scaletoclipped(6,4):rate(movieRate)
+				self:Load(videosplace..callvideo[7]):scaletoclipped(6,4):rate(movieRate)
 			end,
 		};
 


### PR DESCRIPTION
I changed the "hasVideo" function in "00 DanceStages.lua" to load multiple videos and play them randomly
I didn't find that file in the repository only on the releases download files but there is the change

`
  function HasVideo()
	  local basePath = GAMESTATE:GetCurrentSong():GetSongDir()
	  local files = FILEMAN:GetDirListing(GAMESTATE:GetCurrentSong():GetSongDir(), false, false)
	  VideoFileType = {"mp4","avi","mov","m2ts","m2v","wmv","mpg","mpeg"}
	  Z=0
  
      for _, file in ipairs(files) do
          for _, ext in ipairs(VideoFileType) do
              if file:match("%." .. ext .. "$") then -- Verifica si el archivo tiene una extensión de video
                  Z = Z + 1
              end
          end
      end
      return Z > 0
  end
`
 and changed the "LoaderA.lua" in any DanceStage that's the content of this pull-request, be free of modify an improve in any way
